### PR TITLE
First pass updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all    :; dapp build
 clean  :; dapp clean
-test   :; dapp --use solc:0.6.11 test -v
+test   :; dapp --use solc:0.6.12 test -v
 deploy :; dapp create Keg

--- a/src/FlapTap.sol
+++ b/src/FlapTap.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "dss-interfaces/dss/DaiAbstract.sol";
 import "dss-interfaces/dss/DaiJoinAbstract.sol";

--- a/src/FlapTap.sol
+++ b/src/FlapTap.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // FlapTap.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/FlapTap.t.sol
+++ b/src/FlapTap.t.sol
@@ -61,6 +61,7 @@ contract TestVat is DSMath {
     }
 
     function suck(address u, address v, uint rad) auth public {
+        u;
         mint(v, rad);
     }
 
@@ -83,6 +84,7 @@ contract TestFlapper is DSMath {
     }
 
     function kick(uint256 lot, uint256 bid) public returns (uint256 id) {
+        bid;
         id = ++kicks;
         amountAuctioned += lot;
         vat.move(msg.sender, address(this), lot);

--- a/src/FlapTap.t.sol
+++ b/src/FlapTap.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "ds-test/test.sol";
 import "ds-math/math.sol";

--- a/src/FlapTap.t.sol
+++ b/src/FlapTap.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // Keg.t.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/Keg.sol
+++ b/src/Keg.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // Keg.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/Keg.sol
+++ b/src/Keg.sol
@@ -101,11 +101,7 @@ contract Keg {
     // Deauthorize a flight
     function revoke(bytes32 flight) external auth {
         require(flights[flight].length > 0, "Keg/flight-not-set");       // pints will be 0 when not set
-        //for (uint256 i = 0; i < flights[flight].length; i++) {
-        //    delete flights[flight][i];
-        //}
         delete flights[flight];
-        // TODO remove the flights[flight]
         emit Revoke(flight);
     }
 

--- a/src/Keg.sol
+++ b/src/Keg.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "dss-interfaces/ERC/GemAbstract.sol";
 

--- a/src/Keg.sol
+++ b/src/Keg.sol
@@ -101,9 +101,10 @@ contract Keg {
     // Deauthorize a flight
     function revoke(bytes32 flight) external auth {
         require(flights[flight].length > 0, "Keg/flight-not-set");       // pints will be 0 when not set
-        for (uint256 i = 0; i < flights[flight].length; i++) {
-            delete flights[flight][i];
-        }
+        //for (uint256 i = 0; i < flights[flight].length; i++) {
+        //    delete flights[flight][i];
+        //}
+        delete flights[flight];
         // TODO remove the flights[flight]
         emit Revoke(flight);
     }

--- a/src/Keg.t.sol
+++ b/src/Keg.t.sol
@@ -61,6 +61,7 @@ contract TestVat is DSMath {
     }
 
     function suck(address u, address v, uint rad) auth public {
+        u;
         mint(v, rad);
     }
 
@@ -83,6 +84,7 @@ contract TestFlapper is DSMath {
     }
 
     function kick(uint256 lot, uint256 bid) public returns (uint256 id) {
+        bid;
         id = ++kicks;
         amountAuctioned += lot;
         vat.move(msg.sender, address(this), lot);

--- a/src/Keg.t.sol
+++ b/src/Keg.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "ds-test/test.sol";
 import "ds-math/math.sol";
@@ -273,7 +273,7 @@ contract KegTest is DSTest, DSMath {
 
         keg.seat(flight, users, amts);
         dai.mint(me, 100 * WAD);
-        
+
         keg.pour(flight, 10 * WAD);
         assertEq(dai.balanceOf(me), 90 * WAD);
         assertEq(dai.balanceOf(address(user1)), 3 * WAD);
@@ -350,7 +350,7 @@ contract KegTest is DSTest, DSMath {
         amts[1] = 0.25 ether;   // 25% split
         amts[2] = 0.10 ether;   // 10% split
         keg.seat(tap.flight(), users, amts);
-        
+
         uint256 rate = tap.rate();
         uint256 wad = rate * 1 days;        // Due to rounding errors this may not be exactly 1 rad
         hevm.warp(1 days);
@@ -398,7 +398,7 @@ contract KegTest is DSTest, DSMath {
         amts[0] = 0.50 ether;   // 50% split
         amts[1] = 0.50 ether;   // 50% split
         keg.seat(flapTap.flight(), users, amts);
-        
+
         assertEq(flapper.kicks(), 0);
         assertEq(vow.flap(), 1);
         assertEq(flapper.kicks(), 1);
@@ -408,7 +408,7 @@ contract KegTest is DSTest, DSMath {
 
         // Insert the TapFlap in between the vow and flapper
         vow.file("flapper", address(flapTap));
-        
+
         assertEq(vow.flap(), 2);
         assertEq(flapper.kicks(), 2);
         uint256 wad = vow.bump() * flapTap.flow() / RAD;
@@ -438,5 +438,5 @@ contract KegTest is DSTest, DSMath {
         // All dai should be returned to the vow
         assertEq(vat.dai(address(vow)), vow.bump() / 2);
     }
-    
+
 }

--- a/src/Keg.t.sol
+++ b/src/Keg.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // Keg.t.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/Keg.t.sol
+++ b/src/Keg.t.sol
@@ -209,8 +209,8 @@ contract KegTest is DSTest, DSMath {
         assertEq(keg.wards(me),  1);
     }
 
-    function try_flights(address keg, bytes32 flight, uint256 pos) internal returns (bool ok) {
-        (ok,) = address(keg).call(abi.encodeWithSignature("flights(bytes32,uint256)", flight, pos));
+    function try_flights(address _keg, bytes32 _flight, uint256 _pos) internal returns (bool ok) {
+        (ok,) = address(_keg).call(abi.encodeWithSignature("flights(bytes32,uint256)", _flight, _pos));
     }
 
     function test_seat() public {

--- a/src/KegAbstract.sol
+++ b/src/KegAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // KegAbstract.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/Tap.sol
+++ b/src/Tap.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // Tap.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.

--- a/src/Tap.sol
+++ b/src/Tap.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "dss-interfaces/dss/VatAbstract.sol";
 import "dss-interfaces/dss/DaiAbstract.sol";

--- a/src/Tap.t.sol
+++ b/src/Tap.t.sol
@@ -61,6 +61,7 @@ contract TestVat is DSMath {
     }
 
     function suck(address u, address v, uint rad) auth public {
+        u;
         mint(v, rad);
     }
 
@@ -83,6 +84,7 @@ contract TestFlapper is DSMath {
     }
 
     function kick(uint256 lot, uint256 bid) public returns (uint256 id) {
+        bid;
         id = ++kicks;
         amountAuctioned += lot;
         vat.move(msg.sender, address(this), lot);

--- a/src/Tap.t.sol
+++ b/src/Tap.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "ds-test/test.sol";
 import "ds-math/math.sol";

--- a/src/Tap.t.sol
+++ b/src/Tap.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // Keg.t.sol
 
 // Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.


### PR DESCRIPTION
* simplifies `Keg.revoke()` function and adds test of same
* updates to 0.6.12
* Adds SPDX headers
* Clears compilation warnings
* update dss-interfaces